### PR TITLE
Fix ScheduleComparison missing const error in gcc13

### DIFF
--- a/src/graph/graph.h
+++ b/src/graph/graph.h
@@ -61,7 +61,7 @@ class Graph
 
     struct ScheduleComparison
     {
-        bool operator()(const pair<uint64_t, int64_t>& lhs, const pair<uint64_t, int64_t>& rhs)
+        bool operator()(const pair<uint64_t, int64_t>& lhs, const pair<uint64_t, int64_t>& rhs) const
         {
             if (lhs.second != rhs.second)
             {


### PR DESCRIPTION
error info :
src/graph/o3_core_graph.cpp:1012:50:   required from here
/usr/include/c++/13/bits/stl_tree.h:772:15: error: static assertion failed: comparison object must be invocable as const
  772 |               is_invocable_v<const _Compare&, const _Key&, const _Key&>,
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/13/bits/stl_tree.h:772:15: note: ‘std::is_invocable_v<const Graph::ScheduleComparison&, const std::pair<long unsigned int, long int>&, const std::pair<long unsigned int, long int>&>’ evaluates to false